### PR TITLE
Fix player rotation issues for high-latency clients

### DIFF
--- a/1_20_5/data/ridedragon/functions/z_dragon_motion.mcfunction
+++ b/1_20_5/data/ridedragon/functions/z_dragon_motion.mcfunction
@@ -16,7 +16,23 @@ tag @a[nbt={RootVehicle:{Entity:{Tags:["dragonseat_selected"]}}},distance=..7,li
 # by actual harming of the dragon, so set it back to -1.
 data modify entity @s HurtTime set value -1
 
-execute as @a[tag=dragonrider_selected,distance=..7,limit=1] run function ridedragon:z_player_motion
+# If there is a rider
+# Only update the horse and thus player position every other tick to give time for the player 
+# rotation to be updated from client to the server. Update corresponding to two ticks worth
+# of movement instead.
+# Background: Teleporting the horse seems to inhibit player rotation update from the client 
+# for the remaining duration of that tick. On high-latency connections this casued severe issues. 
+execute if score @s rd_tick_phase matches 0 as @a[tag=dragonrider_selected,distance=..7,limit=1] run function ridedragon:z_player_motion_update_tick
+# The other ticks we move the assembly forward one step.
+execute if score @s rd_tick_phase matches 1 as @a[tag=dragonrider_selected,distance=..7,limit=1] run function ridedragon:z_player_motion_non_update_tick
+
+scoreboard players add @s rd_tick_phase 1
+execute if score @s rd_tick_phase matches 2.. run scoreboard players set @s rd_tick_phase 0
+
+# Single tick variation of player momvment. Not used currently.
+#execute as @a[tag=dragonrider_selected,distance=..7,limit=1] run function ridedragon:z_player_motion
+
+# If no rider perform default movement
 execute as @e[type=marker,tag=dragonhelper_selected,distance=..7,limit=1] unless entity @a[distance=..7,limit=1,tag=dragonrider_selected] run function ridedragon:z_no_player_motion
 
 tag @s remove dragonvisible_selected

--- a/1_20_5/data/ridedragon/functions/z_init.mcfunction
+++ b/1_20_5/data/ridedragon/functions/z_init.mcfunction
@@ -12,6 +12,8 @@ scoreboard objectives add rd_silence trigger
 scoreboard objectives add rd_id dummy
 # Cooldown timer per dragon, not player
 scoreboard objectives add rd_fire_cooldown dummy
+# Tick phase per dragon, not player
+scoreboard objectives add rd_tick_phase dummy
 
 #
 # Resets triggers on reload

--- a/1_20_5/data/ridedragon/functions/z_player_motion.mcfunction
+++ b/1_20_5/data/ridedragon/functions/z_player_motion.mcfunction
@@ -13,13 +13,13 @@ execute as @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] at @s 
 
 # Move the dragon to the correct offset relative to the player/dragonseat depending on the low/high speed
 # Low speed
-execute as @e[type=horse,distance=..7,tag=dragonseat_selected,limit=1] at @s rotated ~ 0 positioned ^ ^ ^-2.6 rotated as @s run tp @e[type=ender_dragon,tag=dragonvisible_selected,limit=1,sort=nearest,distance=..7] ~ ~-0.7 ~ ~-180 ~
+execute as @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] at @s rotated ~ 0 positioned ^ ^ ^-2.6 rotated as @s run tp @e[type=ender_dragon,tag=dragonvisible_selected,limit=1,sort=nearest,distance=..7] ~ ~-0.7 ~ ~-180 ~
 # High speed looking up or forward
-execute if entity @s[predicate=ridedragon:book_holder_mainhand] as @e[type=horse,distance=..7,tag=dragonseat_selected,limit=1] at @s positioned ^ ^ ^-2.7 rotated as @s run tp @e[type=ender_dragon,tag=dragonvisible_selected,limit=1,sort=nearest,distance=..7] ~ ~-0.7 ~ ~-180 ~
-execute if entity @s[predicate=ridedragon:book_holder_offhand] as @e[type=horse,distance=..7,tag=dragonseat_selected,limit=1] at @s positioned ^ ^ ^-2.7 rotated as @s run tp @e[type=ender_dragon,tag=dragonvisible_selected,limit=1,sort=nearest,distance=..7] ~ ~-0.7 ~ ~-180 ~
+execute if entity @s[predicate=ridedragon:book_holder_mainhand] as @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] at @s positioned ^ ^ ^-2.7 rotated as @s run tp @e[type=ender_dragon,tag=dragonvisible_selected,limit=1,sort=nearest,distance=..7] ~ ~-0.7 ~ ~-180 ~
+execute if entity @s[predicate=ridedragon:book_holder_offhand] as @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] at @s positioned ^ ^ ^-2.7 rotated as @s run tp @e[type=ender_dragon,tag=dragonvisible_selected,limit=1,sort=nearest,distance=..7] ~ ~-0.7 ~ ~-180 ~
 # High speed looking down
-execute if entity @s[x_rotation=10..90,predicate=ridedragon:book_holder_mainhand] as @e[type=horse,distance=..7,tag=dragonseat_selected,limit=1] at @s rotated ~ 0 positioned ^ ^ ^-2.7 rotated as @s positioned ^ ^ ^-2.2 rotated as @s run tp @e[type=ender_dragon,tag=dragonvisible_selected,limit=1,sort=nearest,distance=..7] ~ ~-0.7 ~ ~-180 ~
-execute if entity @s[x_rotation=10..90,predicate=ridedragon:book_holder_offhand] as @e[type=horse,distance=..7,tag=dragonseat_selected,limit=1] at @s rotated ~ 0 positioned ^ ^ ^-2.7 rotated as @s positioned ^ ^ ^-2.2 rotated as @s run tp @e[type=ender_dragon,tag=dragonvisible_selected,limit=1,sort=nearest,distance=..7] ~ ~-0.7 ~ ~-180 ~
+execute if entity @s[x_rotation=10..90,predicate=ridedragon:book_holder_mainhand] as @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] at @s rotated ~ 0 positioned ^ ^ ^-2.7 rotated as @s positioned ^ ^ ^-2.2 rotated as @s run tp @e[type=ender_dragon,tag=dragonvisible_selected,limit=1,sort=nearest,distance=..7] ~ ~-0.7 ~ ~-180 ~
+execute if entity @s[x_rotation=10..90,predicate=ridedragon:book_holder_offhand] as @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] at @s rotated ~ 0 positioned ^ ^ ^-2.7 rotated as @s positioned ^ ^ ^-2.2 rotated as @s run tp @e[type=ender_dragon,tag=dragonvisible_selected,limit=1,sort=nearest,distance=..7] ~ ~-0.7 ~ ~-180 ~
 
 
 # Check if dragon fireballs are enabled the trigger held and looking sufficiently below the horizon (10 degrees or more)

--- a/1_20_5/data/ridedragon/functions/z_player_motion_non_update_tick.mcfunction
+++ b/1_20_5/data/ridedragon/functions/z_player_motion_non_update_tick.mcfunction
@@ -1,4 +1,6 @@
 # Executed as dragonrider, no position
+# Do not actually move the horse, but project the path forward for the marker and dragon one extra tick 
+# (2x what is in z_player_motion)
 
 # Low speed default
 execute as @s at @s positioned ^ ^ ^0.2 positioned ~ ~-0.85 ~ if block ~ ~-1.3 ~ air run tp @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] ~ ~ ~ ~ ~
@@ -8,7 +10,7 @@ execute if entity @s[predicate=ridedragon:book_holder_mainhand] at @s positioned
 execute if entity @s[predicate=ridedragon:book_holder_offhand] at @s positioned ^ ^ ^1.0 positioned ~ ~-0.85 ~ if block ~ ~-1.3 ~ air run tp @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] ~ ~ ~ ~ ~
 
 #Move the dragonseat (horse) to the helper marker
-execute as @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] at @s run tp @e[type=horse,distance=..7,tag=dragonseat_selected,limit=1] ~ ~ ~ ~ ~
+#execute as @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] at @s run tp @e[type=horse,distance=..7,tag=dragonseat_selected,limit=1] ~ ~ ~ ~ ~
 
 
 # Move the dragon to the correct offset relative to the player/dragonseat depending on the low/high speed

--- a/1_20_5/data/ridedragon/functions/z_player_motion_update_tick.mcfunction
+++ b/1_20_5/data/ridedragon/functions/z_player_motion_update_tick.mcfunction
@@ -1,11 +1,13 @@
 # Executed as dragonrider, no position
+# Project two movement steps forward now that it is actually time to move
+# the horse and player.
 
 # Low speed default
-execute as @s at @s positioned ^ ^ ^0.2 positioned ~ ~-0.85 ~ if block ~ ~-1.3 ~ air run tp @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] ~ ~ ~ ~ ~
+execute as @s at @s positioned ^ ^ ^0.4 positioned ~ ~-0.85 ~ if block ~ ~-1.3 ~ air run tp @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] ~ ~ ~ ~ ~
 
 # High speed when holding the book
-execute if entity @s[predicate=ridedragon:book_holder_mainhand] at @s positioned ^ ^ ^1.0 positioned ~ ~-0.85 ~ if block ~ ~-1.3 ~ air run tp @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] ~ ~ ~ ~ ~
-execute if entity @s[predicate=ridedragon:book_holder_offhand] at @s positioned ^ ^ ^1.0 positioned ~ ~-0.85 ~ if block ~ ~-1.3 ~ air run tp @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] ~ ~ ~ ~ ~
+execute if entity @s[predicate=ridedragon:book_holder_mainhand] at @s positioned ^ ^ ^2.0 positioned ~ ~-0.85 ~ if block ~ ~-1.3 ~ air run tp @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] ~ ~ ~ ~ ~
+execute if entity @s[predicate=ridedragon:book_holder_offhand] at @s positioned ^ ^ ^2.0 positioned ~ ~-0.85 ~ if block ~ ~-1.3 ~ air run tp @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] ~ ~ ~ ~ ~
 
 #Move the dragonseat (horse) to the helper marker
 execute as @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] at @s run tp @e[type=horse,distance=..7,tag=dragonseat_selected,limit=1] ~ ~ ~ ~ ~

--- a/1_21_0/data/ridedragon/function/z_dragon_motion.mcfunction
+++ b/1_21_0/data/ridedragon/function/z_dragon_motion.mcfunction
@@ -16,7 +16,23 @@ tag @a[nbt={RootVehicle:{Entity:{Tags:["dragonseat_selected"]}}},distance=..7,li
 # by actual harming of the dragon, so set it back to -1.
 data modify entity @s HurtTime set value -1
 
-execute as @a[tag=dragonrider_selected,distance=..7,limit=1] run function ridedragon:z_player_motion
+# If there is a rider
+# Only update the horse and thus player position every other tick to give time for the player 
+# rotation to be updated from client to the server. Update corresponding to two ticks worth
+# of movement instead.
+# Background: Teleporting the horse seems to inhibit player rotation update from the client 
+# for the remaining duration of that tick. On high-latency connections this casued severe issues. 
+execute if score @s rd_tick_phase matches 0 as @a[tag=dragonrider_selected,distance=..7,limit=1] run function ridedragon:z_player_motion_update_tick
+# The other ticks we move the assembly forward one step.
+execute if score @s rd_tick_phase matches 1 as @a[tag=dragonrider_selected,distance=..7,limit=1] run function ridedragon:z_player_motion_non_update_tick
+
+scoreboard players add @s rd_tick_phase 1
+execute if score @s rd_tick_phase matches 2.. run scoreboard players set @s rd_tick_phase 0
+
+# Single tick variation of player momvment. Not used currently.
+#execute as @a[tag=dragonrider_selected,distance=..7,limit=1] run function ridedragon:z_player_motion
+
+# If no rider perform default movement
 execute as @e[type=marker,tag=dragonhelper_selected,distance=..7,limit=1] unless entity @a[distance=..7,limit=1,tag=dragonrider_selected] run function ridedragon:z_no_player_motion
 
 tag @s remove dragonvisible_selected

--- a/1_21_0/data/ridedragon/function/z_init.mcfunction
+++ b/1_21_0/data/ridedragon/function/z_init.mcfunction
@@ -12,6 +12,8 @@ scoreboard objectives add rd_silence trigger
 scoreboard objectives add rd_id dummy
 # Cooldown timer per dragon, not player
 scoreboard objectives add rd_fire_cooldown dummy
+# Tick phase per dragon, not player
+scoreboard objectives add rd_tick_phase dummy
 
 #
 # Resets triggers on reload

--- a/1_21_0/data/ridedragon/function/z_player_motion.mcfunction
+++ b/1_21_0/data/ridedragon/function/z_player_motion.mcfunction
@@ -13,13 +13,13 @@ execute as @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] at @s 
 
 # Move the dragon to the correct offset relative to the player/dragonseat depending on the low/high speed
 # Low speed
-execute as @e[type=horse,distance=..7,tag=dragonseat_selected,limit=1] at @s rotated ~ 0 positioned ^ ^ ^-2.6 rotated as @s run tp @e[type=ender_dragon,tag=dragonvisible_selected,limit=1,sort=nearest,distance=..7] ~ ~-0.7 ~ ~-180 ~
+execute as @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] at @s rotated ~ 0 positioned ^ ^ ^-2.6 rotated as @s run tp @e[type=ender_dragon,tag=dragonvisible_selected,limit=1,sort=nearest,distance=..7] ~ ~-0.7 ~ ~-180 ~
 # High speed looking up or forward
-execute if entity @s[predicate=ridedragon:book_holder_mainhand] as @e[type=horse,distance=..7,tag=dragonseat_selected,limit=1] at @s positioned ^ ^ ^-2.7 rotated as @s run tp @e[type=ender_dragon,tag=dragonvisible_selected,limit=1,sort=nearest,distance=..7] ~ ~-0.7 ~ ~-180 ~
-execute if entity @s[predicate=ridedragon:book_holder_offhand] as @e[type=horse,distance=..7,tag=dragonseat_selected,limit=1] at @s positioned ^ ^ ^-2.7 rotated as @s run tp @e[type=ender_dragon,tag=dragonvisible_selected,limit=1,sort=nearest,distance=..7] ~ ~-0.7 ~ ~-180 ~
+execute if entity @s[predicate=ridedragon:book_holder_mainhand] as @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] at @s positioned ^ ^ ^-2.7 rotated as @s run tp @e[type=ender_dragon,tag=dragonvisible_selected,limit=1,sort=nearest,distance=..7] ~ ~-0.7 ~ ~-180 ~
+execute if entity @s[predicate=ridedragon:book_holder_offhand] as @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] at @s positioned ^ ^ ^-2.7 rotated as @s run tp @e[type=ender_dragon,tag=dragonvisible_selected,limit=1,sort=nearest,distance=..7] ~ ~-0.7 ~ ~-180 ~
 # High speed looking down
-execute if entity @s[x_rotation=10..90,predicate=ridedragon:book_holder_mainhand] as @e[type=horse,distance=..7,tag=dragonseat_selected,limit=1] at @s rotated ~ 0 positioned ^ ^ ^-2.7 rotated as @s positioned ^ ^ ^-2.2 rotated as @s run tp @e[type=ender_dragon,tag=dragonvisible_selected,limit=1,sort=nearest,distance=..7] ~ ~-0.7 ~ ~-180 ~
-execute if entity @s[x_rotation=10..90,predicate=ridedragon:book_holder_offhand] as @e[type=horse,distance=..7,tag=dragonseat_selected,limit=1] at @s rotated ~ 0 positioned ^ ^ ^-2.7 rotated as @s positioned ^ ^ ^-2.2 rotated as @s run tp @e[type=ender_dragon,tag=dragonvisible_selected,limit=1,sort=nearest,distance=..7] ~ ~-0.7 ~ ~-180 ~
+execute if entity @s[x_rotation=10..90,predicate=ridedragon:book_holder_mainhand] as @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] at @s rotated ~ 0 positioned ^ ^ ^-2.7 rotated as @s positioned ^ ^ ^-2.2 rotated as @s run tp @e[type=ender_dragon,tag=dragonvisible_selected,limit=1,sort=nearest,distance=..7] ~ ~-0.7 ~ ~-180 ~
+execute if entity @s[x_rotation=10..90,predicate=ridedragon:book_holder_offhand] as @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] at @s rotated ~ 0 positioned ^ ^ ^-2.7 rotated as @s positioned ^ ^ ^-2.2 rotated as @s run tp @e[type=ender_dragon,tag=dragonvisible_selected,limit=1,sort=nearest,distance=..7] ~ ~-0.7 ~ ~-180 ~
 
 
 # Check if dragon fireballs are enabled the trigger held and looking sufficiently below the horizon (10 degrees or more)

--- a/1_21_0/data/ridedragon/function/z_player_motion_non_update_tick.mcfunction
+++ b/1_21_0/data/ridedragon/function/z_player_motion_non_update_tick.mcfunction
@@ -1,4 +1,6 @@
 # Executed as dragonrider, no position
+# Do not actually move the horse, but project the path forward for the marker and dragon one extra tick 
+# (2x what is in z_player_motion)
 
 # Low speed default
 execute as @s at @s positioned ^ ^ ^0.2 positioned ~ ~-0.85 ~ if block ~ ~-1.3 ~ air run tp @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] ~ ~ ~ ~ ~
@@ -8,7 +10,7 @@ execute if entity @s[predicate=ridedragon:book_holder_mainhand] at @s positioned
 execute if entity @s[predicate=ridedragon:book_holder_offhand] at @s positioned ^ ^ ^1.0 positioned ~ ~-0.85 ~ if block ~ ~-1.3 ~ air run tp @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] ~ ~ ~ ~ ~
 
 #Move the dragonseat (horse) to the helper marker
-execute as @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] at @s run tp @e[type=horse,distance=..7,tag=dragonseat_selected,limit=1] ~ ~ ~ ~ ~
+#execute as @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] at @s run tp @e[type=horse,distance=..7,tag=dragonseat_selected,limit=1] ~ ~ ~ ~ ~
 
 
 # Move the dragon to the correct offset relative to the player/dragonseat depending on the low/high speed

--- a/1_21_0/data/ridedragon/function/z_player_motion_update_tick.mcfunction
+++ b/1_21_0/data/ridedragon/function/z_player_motion_update_tick.mcfunction
@@ -1,11 +1,13 @@
 # Executed as dragonrider, no position
+# Project two movement steps forward now that it is actually time to move
+# the horse and player.
 
 # Low speed default
-execute as @s at @s positioned ^ ^ ^0.2 positioned ~ ~-0.85 ~ if block ~ ~-1.3 ~ air run tp @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] ~ ~ ~ ~ ~
+execute as @s at @s positioned ^ ^ ^0.4 positioned ~ ~-0.85 ~ if block ~ ~-1.3 ~ air run tp @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] ~ ~ ~ ~ ~
 
 # High speed when holding the book
-execute if entity @s[predicate=ridedragon:book_holder_mainhand] at @s positioned ^ ^ ^1.0 positioned ~ ~-0.85 ~ if block ~ ~-1.3 ~ air run tp @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] ~ ~ ~ ~ ~
-execute if entity @s[predicate=ridedragon:book_holder_offhand] at @s positioned ^ ^ ^1.0 positioned ~ ~-0.85 ~ if block ~ ~-1.3 ~ air run tp @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] ~ ~ ~ ~ ~
+execute if entity @s[predicate=ridedragon:book_holder_mainhand] at @s positioned ^ ^ ^2.0 positioned ~ ~-0.85 ~ if block ~ ~-1.3 ~ air run tp @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] ~ ~ ~ ~ ~
+execute if entity @s[predicate=ridedragon:book_holder_offhand] at @s positioned ^ ^ ^2.0 positioned ~ ~-0.85 ~ if block ~ ~-1.3 ~ air run tp @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] ~ ~ ~ ~ ~
 
 #Move the dragonseat (horse) to the helper marker
 execute as @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] at @s run tp @e[type=horse,distance=..7,tag=dragonseat_selected,limit=1] ~ ~ ~ ~ ~

--- a/1_21_4/data/ridedragon/function/z_dragon_motion.mcfunction
+++ b/1_21_4/data/ridedragon/function/z_dragon_motion.mcfunction
@@ -16,7 +16,23 @@ tag @a[nbt={RootVehicle:{Entity:{Tags:["dragonseat_selected"]}}},distance=..7,li
 # by actual harming of the dragon, so set it back to -1.
 data modify entity @s HurtTime set value -1
 
-execute as @a[tag=dragonrider_selected,distance=..7,limit=1] run function ridedragon:z_player_motion
+# If there is a rider
+# Only update the horse and thus player position every other tick to give time for the player 
+# rotation to be updated from client to the server. Update corresponding to two ticks worth
+# of movement instead.
+# Background: Teleporting the horse seems to inhibit player rotation update from the client 
+# for the remaining duration of that tick. On high-latency connections this casued severe issues. 
+execute if score @s rd_tick_phase matches 0 as @a[tag=dragonrider_selected,distance=..7,limit=1] run function ridedragon:z_player_motion_update_tick
+# The other ticks we move the assembly forward one step.
+execute if score @s rd_tick_phase matches 1 as @a[tag=dragonrider_selected,distance=..7,limit=1] run function ridedragon:z_player_motion_non_update_tick
+
+scoreboard players add @s rd_tick_phase 1
+execute if score @s rd_tick_phase matches 2.. run scoreboard players set @s rd_tick_phase 0
+
+# Single tick variation of player momvment. Not used currently.
+#execute as @a[tag=dragonrider_selected,distance=..7,limit=1] run function ridedragon:z_player_motion
+
+# If no rider perform default movement
 execute as @e[type=marker,tag=dragonhelper_selected,distance=..7,limit=1] unless entity @a[distance=..7,limit=1,tag=dragonrider_selected] run function ridedragon:z_no_player_motion
 
 tag @s remove dragonvisible_selected

--- a/1_21_4/data/ridedragon/function/z_init.mcfunction
+++ b/1_21_4/data/ridedragon/function/z_init.mcfunction
@@ -12,6 +12,8 @@ scoreboard objectives add rd_silence trigger
 scoreboard objectives add rd_id dummy
 # Cooldown timer per dragon, not player
 scoreboard objectives add rd_fire_cooldown dummy
+# Tick phase per dragon, not player
+scoreboard objectives add rd_tick_phase dummy
 
 #
 # Resets triggers on reload

--- a/1_21_4/data/ridedragon/function/z_player_motion.mcfunction
+++ b/1_21_4/data/ridedragon/function/z_player_motion.mcfunction
@@ -13,13 +13,13 @@ execute as @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] at @s 
 
 # Move the dragon to the correct offset relative to the player/dragonseat depending on the low/high speed
 # Low speed
-execute as @e[type=horse,distance=..7,tag=dragonseat_selected,limit=1] at @s rotated ~ 0 positioned ^ ^ ^-2.6 rotated as @s run tp @e[type=ender_dragon,tag=dragonvisible_selected,limit=1,sort=nearest,distance=..7] ~ ~-0.7 ~ ~-180 ~
+execute as @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] at @s rotated ~ 0 positioned ^ ^ ^-2.6 rotated as @s run tp @e[type=ender_dragon,tag=dragonvisible_selected,limit=1,sort=nearest,distance=..7] ~ ~-0.7 ~ ~-180 ~
 # High speed looking up or forward
-execute if entity @s[predicate=ridedragon:book_holder_mainhand] as @e[type=horse,distance=..7,tag=dragonseat_selected,limit=1] at @s positioned ^ ^ ^-2.7 rotated as @s run tp @e[type=ender_dragon,tag=dragonvisible_selected,limit=1,sort=nearest,distance=..7] ~ ~-0.7 ~ ~-180 ~
-execute if entity @s[predicate=ridedragon:book_holder_offhand] as @e[type=horse,distance=..7,tag=dragonseat_selected,limit=1] at @s positioned ^ ^ ^-2.7 rotated as @s run tp @e[type=ender_dragon,tag=dragonvisible_selected,limit=1,sort=nearest,distance=..7] ~ ~-0.7 ~ ~-180 ~
+execute if entity @s[predicate=ridedragon:book_holder_mainhand] as @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] at @s positioned ^ ^ ^-2.7 rotated as @s run tp @e[type=ender_dragon,tag=dragonvisible_selected,limit=1,sort=nearest,distance=..7] ~ ~-0.7 ~ ~-180 ~
+execute if entity @s[predicate=ridedragon:book_holder_offhand] as @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] at @s positioned ^ ^ ^-2.7 rotated as @s run tp @e[type=ender_dragon,tag=dragonvisible_selected,limit=1,sort=nearest,distance=..7] ~ ~-0.7 ~ ~-180 ~
 # High speed looking down
-execute if entity @s[x_rotation=10..90,predicate=ridedragon:book_holder_mainhand] as @e[type=horse,distance=..7,tag=dragonseat_selected,limit=1] at @s rotated ~ 0 positioned ^ ^ ^-2.7 rotated as @s positioned ^ ^ ^-2.2 rotated as @s run tp @e[type=ender_dragon,tag=dragonvisible_selected,limit=1,sort=nearest,distance=..7] ~ ~-0.7 ~ ~-180 ~
-execute if entity @s[x_rotation=10..90,predicate=ridedragon:book_holder_offhand] as @e[type=horse,distance=..7,tag=dragonseat_selected,limit=1] at @s rotated ~ 0 positioned ^ ^ ^-2.7 rotated as @s positioned ^ ^ ^-2.2 rotated as @s run tp @e[type=ender_dragon,tag=dragonvisible_selected,limit=1,sort=nearest,distance=..7] ~ ~-0.7 ~ ~-180 ~
+execute if entity @s[x_rotation=10..90,predicate=ridedragon:book_holder_mainhand] as @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] at @s rotated ~ 0 positioned ^ ^ ^-2.7 rotated as @s positioned ^ ^ ^-2.2 rotated as @s run tp @e[type=ender_dragon,tag=dragonvisible_selected,limit=1,sort=nearest,distance=..7] ~ ~-0.7 ~ ~-180 ~
+execute if entity @s[x_rotation=10..90,predicate=ridedragon:book_holder_offhand] as @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] at @s rotated ~ 0 positioned ^ ^ ^-2.7 rotated as @s positioned ^ ^ ^-2.2 rotated as @s run tp @e[type=ender_dragon,tag=dragonvisible_selected,limit=1,sort=nearest,distance=..7] ~ ~-0.7 ~ ~-180 ~
 
 
 # Check if dragon fireballs are enabled the trigger held and looking sufficiently below the horizon (10 degrees or more)

--- a/1_21_4/data/ridedragon/function/z_player_motion_non_update_tick.mcfunction
+++ b/1_21_4/data/ridedragon/function/z_player_motion_non_update_tick.mcfunction
@@ -1,4 +1,6 @@
 # Executed as dragonrider, no position
+# Do not actually move the horse, but project the path forward for the marker and dragon one extra tick 
+# (2x what is in z_player_motion)
 
 # Low speed default
 execute as @s at @s positioned ^ ^ ^0.2 positioned ~ ~-0.85 ~ if block ~ ~-1.3 ~ air run tp @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] ~ ~ ~ ~ ~
@@ -8,7 +10,7 @@ execute if entity @s[predicate=ridedragon:book_holder_mainhand] at @s positioned
 execute if entity @s[predicate=ridedragon:book_holder_offhand] at @s positioned ^ ^ ^1.0 positioned ~ ~-0.85 ~ if block ~ ~-1.3 ~ air run tp @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] ~ ~ ~ ~ ~
 
 #Move the dragonseat (horse) to the helper marker
-execute as @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] at @s run tp @e[type=horse,distance=..7,tag=dragonseat_selected,limit=1] ~ ~ ~ ~ ~
+#execute as @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] at @s run tp @e[type=horse,distance=..7,tag=dragonseat_selected,limit=1] ~ ~ ~ ~ ~
 
 
 # Move the dragon to the correct offset relative to the player/dragonseat depending on the low/high speed

--- a/1_21_4/data/ridedragon/function/z_player_motion_update_tick.mcfunction
+++ b/1_21_4/data/ridedragon/function/z_player_motion_update_tick.mcfunction
@@ -1,11 +1,13 @@
 # Executed as dragonrider, no position
+# Project two movement steps forward now that it is actually time to move
+# the horse and player.
 
 # Low speed default
-execute as @s at @s positioned ^ ^ ^0.2 positioned ~ ~-0.85 ~ if block ~ ~-1.3 ~ air run tp @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] ~ ~ ~ ~ ~
+execute as @s at @s positioned ^ ^ ^0.4 positioned ~ ~-0.85 ~ if block ~ ~-1.3 ~ air run tp @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] ~ ~ ~ ~ ~
 
 # High speed when holding the book
-execute if entity @s[predicate=ridedragon:book_holder_mainhand] at @s positioned ^ ^ ^1.0 positioned ~ ~-0.85 ~ if block ~ ~-1.3 ~ air run tp @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] ~ ~ ~ ~ ~
-execute if entity @s[predicate=ridedragon:book_holder_offhand] at @s positioned ^ ^ ^1.0 positioned ~ ~-0.85 ~ if block ~ ~-1.3 ~ air run tp @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] ~ ~ ~ ~ ~
+execute if entity @s[predicate=ridedragon:book_holder_mainhand] at @s positioned ^ ^ ^2.0 positioned ~ ~-0.85 ~ if block ~ ~-1.3 ~ air run tp @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] ~ ~ ~ ~ ~
+execute if entity @s[predicate=ridedragon:book_holder_offhand] at @s positioned ^ ^ ^2.0 positioned ~ ~-0.85 ~ if block ~ ~-1.3 ~ air run tp @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] ~ ~ ~ ~ ~
 
 #Move the dragonseat (horse) to the helper marker
 execute as @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] at @s run tp @e[type=horse,distance=..7,tag=dragonseat_selected,limit=1] ~ ~ ~ ~ ~

--- a/Changes.txt
+++ b/Changes.txt
@@ -1,3 +1,9 @@
+rev 1.7
+---------
+
+- all versions: worked around a bug affecting long latency clients, rendering
+                their controls extremely sluggish and jerky
+
 rev 1.6
 ---------
 

--- a/data/ridedragon/functions/z_dragon_motion.mcfunction
+++ b/data/ridedragon/functions/z_dragon_motion.mcfunction
@@ -16,7 +16,23 @@ tag @a[nbt={RootVehicle:{Entity:{Tags:["dragonseat_selected"]}}},distance=..7,li
 # by actual harming of the dragon, so set it back to -1.
 data modify entity @s HurtTime set value -1
 
-execute as @a[tag=dragonrider_selected,distance=..7,limit=1] run function ridedragon:z_player_motion
+# If there is a rider
+# Only update the horse and thus player position every other tick to give time for the player 
+# rotation to be updated from client to the server. Update corresponding to two ticks worth
+# of movement instead.
+# Background: Teleporting the horse seems to inhibit player rotation update from the client 
+# for the remaining duration of that tick. On high-latency connections this casued severe issues. 
+execute if score @s rd_tick_phase matches 0 as @a[tag=dragonrider_selected,distance=..7,limit=1] run function ridedragon:z_player_motion_update_tick
+# The other ticks we move the assembly forward one step.
+execute if score @s rd_tick_phase matches 1 as @a[tag=dragonrider_selected,distance=..7,limit=1] run function ridedragon:z_player_motion_non_update_tick
+
+scoreboard players add @s rd_tick_phase 1
+execute if score @s rd_tick_phase matches 2.. run scoreboard players set @s rd_tick_phase 0
+
+# Single tick variation of player momvment. Not used currently.
+#execute as @a[tag=dragonrider_selected,distance=..7,limit=1] run function ridedragon:z_player_motion
+
+# If no rider perform default movement
 execute as @e[type=marker,tag=dragonhelper_selected,distance=..7,limit=1] unless entity @a[distance=..7,limit=1,tag=dragonrider_selected] run function ridedragon:z_no_player_motion
 
 tag @s remove dragonvisible_selected

--- a/data/ridedragon/functions/z_init.mcfunction
+++ b/data/ridedragon/functions/z_init.mcfunction
@@ -12,6 +12,8 @@ scoreboard objectives add rd_silence trigger
 scoreboard objectives add rd_id dummy
 # Cooldown timer per dragon, not player
 scoreboard objectives add rd_fire_cooldown dummy
+# Tick phase per dragon, not player
+scoreboard objectives add rd_tick_phase dummy
 
 #
 # Resets triggers on reload

--- a/data/ridedragon/functions/z_player_motion_non_update_tick.mcfunction
+++ b/data/ridedragon/functions/z_player_motion_non_update_tick.mcfunction
@@ -1,4 +1,6 @@
 # Executed as dragonrider, no position
+# Do not actually move the horse, but project the path forward for the marker and dragon one extra tick 
+# (2x what is in z_player_motion)
 
 # Low speed default
 execute as @s at @s positioned ^ ^ ^0.2 positioned ~ ~-0.85 ~ if block ~ ~-1.3 ~ air run tp @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] ~ ~ ~ ~ ~
@@ -8,7 +10,7 @@ execute if entity @s[predicate=ridedragon:book_holder_mainhand] at @s positioned
 execute if entity @s[predicate=ridedragon:book_holder_offhand] at @s positioned ^ ^ ^1.0 positioned ~ ~-0.85 ~ if block ~ ~-1.3 ~ air run tp @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] ~ ~ ~ ~ ~
 
 #Move the dragonseat (horse) to the helper marker
-execute as @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] at @s run tp @e[type=horse,distance=..7,tag=dragonseat_selected,limit=1] ~ ~ ~ ~ ~
+#execute as @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] at @s run tp @e[type=horse,distance=..7,tag=dragonseat_selected,limit=1] ~ ~ ~ ~ ~
 
 
 # Move the dragon to the correct offset relative to the player/dragonseat depending on the low/high speed

--- a/data/ridedragon/functions/z_player_motion_update_tick.mcfunction
+++ b/data/ridedragon/functions/z_player_motion_update_tick.mcfunction
@@ -1,11 +1,13 @@
 # Executed as dragonrider, no position
+# Project two movement steps forward now that it is actually time to move
+# the horse and player.
 
 # Low speed default
-execute as @s at @s positioned ^ ^ ^0.2 positioned ~ ~-0.85 ~ if block ~ ~-1.3 ~ air run tp @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] ~ ~ ~ ~ ~
+execute as @s at @s positioned ^ ^ ^0.4 positioned ~ ~-0.85 ~ if block ~ ~-1.3 ~ air run tp @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] ~ ~ ~ ~ ~
 
 # High speed when holding the book
-execute if entity @s[predicate=ridedragon:book_holder_mainhand] at @s positioned ^ ^ ^1.0 positioned ~ ~-0.85 ~ if block ~ ~-1.3 ~ air run tp @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] ~ ~ ~ ~ ~
-execute if entity @s[predicate=ridedragon:book_holder_offhand] at @s positioned ^ ^ ^1.0 positioned ~ ~-0.85 ~ if block ~ ~-1.3 ~ air run tp @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] ~ ~ ~ ~ ~
+execute if entity @s[predicate=ridedragon:book_holder_mainhand] at @s positioned ^ ^ ^2.0 positioned ~ ~-0.85 ~ if block ~ ~-1.3 ~ air run tp @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] ~ ~ ~ ~ ~
+execute if entity @s[predicate=ridedragon:book_holder_offhand] at @s positioned ^ ^ ^2.0 positioned ~ ~-0.85 ~ if block ~ ~-1.3 ~ air run tp @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] ~ ~ ~ ~ ~
 
 #Move the dragonseat (horse) to the helper marker
 execute as @e[type=marker,distance=..7,tag=dragonhelper_selected,limit=1] at @s run tp @e[type=horse,distance=..7,tag=dragonseat_selected,limit=1] ~ ~ ~ ~ ~


### PR DESCRIPTION
The player motion is split into two phases, one tick apart. Fixes issue #5.

In the first tick the visible motion is update with the movment expected during one tick (0.2 for slow speed and 1.0 while holding the Book of Dragons), but the horse and player are not moved. This allows one full tick for the client to server update packet to arrive and be processed.

In the second tick both the visible elements and the player are moved two ticks worth of distance, i.e. 0.4 / 2.0.

This will introduce visible artifacts since the player is only updated every second tick, making the dragon appear to move forward/back a little every other tick from the player point of view.

Background:
It seems that teleporting the horse the player rides temporarily resets the Rotation attribute of the playter, server side. However, the client side is in control for player mounted hourses and thus this erronous rotation is corrected next tick. For long latency client connections this correction may arrive too late so we end up in a loop of perpetually server-overridden player Rotation values until chance makes the server late, giving the client packet a chance to update the server state.